### PR TITLE
refactor: 인증 관련 내부 로직 변경

### DIFF
--- a/src/main/java/com/sparcs/teamf/api/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/sparcs/teamf/api/auth/jwt/JwtFilter.java
@@ -3,37 +3,35 @@ package com.sparcs.teamf.api.auth.jwt;
 import java.io.IOException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
-import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
 @RequiredArgsConstructor
-public class JwtFilter extends GenericFilterBean {
+public class JwtFilter extends OncePerRequestFilter {
 
     public static final String BEARER = "Bearer ";
     private final TokenProvider tokenProvider;
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-            throws IOException, ServletException {
-        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-        String jwt = resolveToken(httpServletRequest);
-        String requestURI = httpServletRequest.getRequestURI();
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String jwt = resolveToken(request);
+        String requestURI = request.getRequestURI();
 
         if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
             Authentication authentication = tokenProvider.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
             log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
         }
-        chain.doFilter(request, response);
+        filterChain.doFilter(request, response);
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/sparcs/teamf/api/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/sparcs/teamf/api/auth/jwt/TokenProvider.java
@@ -14,8 +14,8 @@ import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Date;
 import java.util.List;
+import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class TokenProvider implements InitializingBean {
+public class TokenProvider {
     private static final String MEMBER_ID = "memberId";
 
     private final String secret;
@@ -41,7 +41,7 @@ public class TokenProvider implements InitializingBean {
         this.refreshTokenValidityInSeconds = refreshTokenValidityInSeconds * 1000;
     }
 
-    @Override
+    @PostConstruct
     public void afterPropertiesSet() {
         byte[] keyBytes = Decoders.BASE64.decode(secret);
         this.key = Keys.hmacShaKeyFor(keyBytes);

--- a/src/main/java/com/sparcs/teamf/api/auth/service/AuthService.java
+++ b/src/main/java/com/sparcs/teamf/api/auth/service/AuthService.java
@@ -21,9 +21,7 @@ public class AuthService {
     public TokenResponse login(String email, String password) {
         Member member = getMemberByEmail(email);
         validatePassword(password, member.getPassword());
-
-        TokenResponse tokenResponse = resolveToken(member.getId(), member.getEmail());
-        return new TokenResponse(member.getId(), tokenResponse.accessToken(), tokenResponse.refreshToken());
+        return tokenProvider.createToken(member.getId(), member.getEmail());
     }
 
     public TokenResponse refresh(String refreshToken) {
@@ -46,9 +44,5 @@ public class AuthService {
         if (!memberRepository.existsById(memberId)) {
             throw new MemberNotFoundException();
         }
-    }
-
-    private TokenResponse resolveToken(Long memberId, String email) {
-        return tokenProvider.createToken(memberId, email);
     }
 }

--- a/src/main/java/com/sparcs/teamf/api/signup/service/SignupService.java
+++ b/src/main/java/com/sparcs/teamf/api/signup/service/SignupService.java
@@ -28,20 +28,20 @@ public class SignupService {
         if (!password.equals(confirmPassword)) {
             throw new PasswordMismatchException();
         }
-        checkEmailAlreadyRegistered(email);
-        checkEmailVerified(email);
+        validateAlreadyRegistered(email);
+        handleUnverifiedEmail(email);
 
         Member member = Member.of(generateRandomNickname(), email, passwordEncoder.encode(password));
         memberRepository.save(member);
     }
 
-    private void checkEmailAlreadyRegistered(String email) {
+    private void validateAlreadyRegistered(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new DuplicateEmailException();
         }
     }
 
-    private void checkEmailVerified(String email) {
+    private void handleUnverifiedEmail(String email) {
         EmailAuth emailAuth = emailAuthRepository.findFirstByEmailOrderByCreatedDateDesc(email)
                 .orElseThrow(EmailRequestRequiredException::new);
         if (!emailAuth.getIsAuthenticated()) {


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- 인증 관련 내부 로직 변경

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
1. InitializingBean 대신 PostConstruct를 사용하도록 변경
- `PostConstruct` 어노테이션을 사용하면 빈을 초기화하는 데 필요한 메서드를 지정할 수 있기 때문에 스프링에서 더 권장되는 방법이라고 합니다.
2. GenericFilterBean 대신 OncePerRequestFilter을 상속 받도록 변경
- `GenericFilterBean`는 필터 체인에서 여러 번 호출될 수 있기 때문에 `OncePerRequestFilter`를 상속 받아 해당 필터가 한번만 호출되도록 보장해주었습니다.
- `OncePerRequestFilter`는 `doFilterInternal()` 메서드를 구현하고 있기 때문에 `HttpServletRequest`에 대한 캐스팅 없이 사용할 수 있습니다.
3. 인라인화, 메서드 명 변경
- 불필요한 인라인화를 제거해주었습니다.


<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List

- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
