### PR TITLE
feat: 멤버 프로필 기능 구현

### DIFF
--- a/src/main/java/com/sparcs/teamf/api/auth/dto/EffectiveMember.java
+++ b/src/main/java/com/sparcs/teamf/api/auth/dto/EffectiveMember.java
@@ -1,11 +1,13 @@
 package com.sparcs.teamf.api.auth.dto;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.Collection;
+import java.util.List;
+
+
+@io.swagger.v3.oas.annotations.Hidden
 public class EffectiveMember implements UserDetails {
 
     private final Long memberId;

--- a/src/main/java/com/sparcs/teamf/api/member/controller/MemberController.java
+++ b/src/main/java/com/sparcs/teamf/api/member/controller/MemberController.java
@@ -5,7 +5,6 @@ import com.sparcs.teamf.api.auth.dto.ResetPasswordEmailRequest;
 import com.sparcs.teamf.api.member.dto.MemberProfileResponse;
 import com.sparcs.teamf.api.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/sparcs/teamf/api/member/controller/MemberController.java
+++ b/src/main/java/com/sparcs/teamf/api/member/controller/MemberController.java
@@ -1,6 +1,8 @@
 package com.sparcs.teamf.api.member.controller;
 
+import com.sparcs.teamf.api.auth.dto.EffectiveMember;
 import com.sparcs.teamf.api.auth.dto.ResetPasswordEmailRequest;
+import com.sparcs.teamf.api.member.dto.MemberProfileResponse;
 import com.sparcs.teamf.api.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -8,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,5 +35,10 @@ public class MemberController {
             @ApiResponse(responseCode = "404", description = "not found")})
     public void resetPassword(@RequestBody @Valid ResetPasswordEmailRequest request) {
         memberService.resetPassword(request.email(), request.password(), request.confirmPassword());
+    }
+
+    @PostMapping("/profile")
+    public MemberProfileResponse getMemberProfile(@AuthenticationPrincipal EffectiveMember member) {
+        return memberService.getMemberProfile(member.getMemberId());
     }
 }

--- a/src/main/java/com/sparcs/teamf/api/member/controller/MemberController.java
+++ b/src/main/java/com/sparcs/teamf/api/member/controller/MemberController.java
@@ -52,7 +52,7 @@ public class MemberController {
             @ApiResponse(responseCode = "400", description = "bad request", content = @Content),
             @ApiResponse(responseCode = "401", description = "unauthorized", content = @Content),
             @ApiResponse(responseCode = "404", description = "not found", content = @Content)})
-    public MemberProfileResponse getMemberProfile(@Parameter(hidden = true) @AuthenticationPrincipal EffectiveMember member) {
+    public MemberProfileResponse getMemberProfile(@AuthenticationPrincipal EffectiveMember member) {
         return memberService.getMemberProfile(member.getMemberId());
     }
 }

--- a/src/main/java/com/sparcs/teamf/api/member/controller/MemberController.java
+++ b/src/main/java/com/sparcs/teamf/api/member/controller/MemberController.java
@@ -5,16 +5,22 @@ import com.sparcs.teamf.api.auth.dto.ResetPasswordEmailRequest;
 import com.sparcs.teamf.api.member.dto.MemberProfileResponse;
 import com.sparcs.teamf.api.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 @Tag(name = "Members")
 @RestController
@@ -37,8 +43,16 @@ public class MemberController {
         memberService.resetPassword(request.email(), request.password(), request.confirmPassword());
     }
 
-    @PostMapping("/profile")
-    public MemberProfileResponse getMemberProfile(@AuthenticationPrincipal EffectiveMember member) {
+    @GetMapping("/profile")
+    @Operation(summary = "멤버 프로필 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "successful operation", content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MemberProfileResponse.class))}),
+            @ApiResponse(responseCode = "500", description = "internal server error", content = @Content),
+            @ApiResponse(responseCode = "400", description = "bad request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "unauthorized", content = @Content),
+            @ApiResponse(responseCode = "404", description = "not found", content = @Content)})
+    public MemberProfileResponse getMemberProfile(@Parameter(hidden = true) @AuthenticationPrincipal EffectiveMember member) {
         return memberService.getMemberProfile(member.getMemberId());
     }
 }

--- a/src/main/java/com/sparcs/teamf/api/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/sparcs/teamf/api/member/dto/MemberProfileResponse.java
@@ -1,0 +1,5 @@
+package com.sparcs.teamf.api.member.dto;
+
+public record MemberProfileResponse(String nickname,
+                                    String email) {
+}

--- a/src/main/java/com/sparcs/teamf/api/member/service/MemberService.java
+++ b/src/main/java/com/sparcs/teamf/api/member/service/MemberService.java
@@ -4,6 +4,7 @@ import static com.sparcs.teamf.domain.emailauth.Event.RESET_PASSWORD;
 
 import com.sparcs.teamf.api.emailauth.exception.EmailRequestRequiredException;
 import com.sparcs.teamf.api.emailauth.exception.UnverifiedEmailException;
+import com.sparcs.teamf.api.member.dto.MemberProfileResponse;
 import com.sparcs.teamf.api.member.exception.MemberNotFoundException;
 import com.sparcs.teamf.api.signup.exception.PasswordMismatchException;
 import com.sparcs.teamf.domain.emailauth.EmailAuth;
@@ -31,6 +32,11 @@ public class MemberService {
         handleUnverifiedEmail(email);
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         member.updatePassword(passwordEncoder.encode(password));
+    }
+
+    public MemberProfileResponse getMemberProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        return new MemberProfileResponse(member.getNickname(), member.getEmail());
     }
 
     private void handleUnverifiedEmail(String email) {


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- Resolve: #26 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- 멤버 프로필 조회

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- AuthenticationPrincipal로 인증 객체를 가져와 구현해주었습니다.  
- swagger에서 제공해주는 `@Parameter(hidden = true)` 사용한 이유는 다음과 같습니다.
`AuthenticationPrincipal` 어노테이션으로 주입되는 객체의 형식을 UserDetails 타입으로 인식하고 swagger는 이에 대한 스키마를 만들기 때문에 해당 파라미터를 인식하지 못하게 하였습니다.
EffectiveMember 의 멤버 변수에 `@io.swagger.v3.oas.annotations.Hidden` 어노테이션으로 한번에 표시하지 않을 요소를 지정하지 않을 수도 있는데 어떤게 좋은 방법인지 헷갈리네요.. 🤔

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List

- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
